### PR TITLE
Ensure CreateObjectFromData returns nullptr when needed

### DIFF
--- a/Plugins/SqliteGameDB/Source/SqliteGameDB/Private/DbStatement.cpp
+++ b/Plugins/SqliteGameDB/Source/SqliteGameDB/Private/DbStatement.cpp
@@ -1,4 +1,4 @@
-﻿/* © Copyright 2022 Graham Chabas, All Rights Reserved. */
+/* © Copyright 2022 Graham Chabas, All Rights Reserved. */
 
 #include "DbStatement.h"
 #include "UObject/TextProperty.h"
@@ -290,13 +290,14 @@ TArray<FProperty*> UDbStatement::FindSaveProperties(UStruct* ThisClass)
 	return SaveProperties;
 }
 
-void UDbStatement::ReadIntoObject(UObject* ObjectToFill)
+bool UDbStatement::ReadIntoObject(UObject* ObjectToFill)
 {
 	/* NOTE: ObjectToFill->StaticClass() wont work here, as the pointer is UObject*,
 	we would get the UClass* for UObject and not the underlying class.
 	Instead we use GetClass() which returns the UClass for the 'actual' derived class. */
 	UClass*            ObjectClass   = ObjectToFill->GetClass();
 	TArray<FProperty*> SaveGameProps = FindSaveProperties(ObjectClass);
+	bool rc = true;
 
 	check(PreparedStatement && PreparedStatement->IsValid());
 
@@ -355,10 +356,14 @@ void UDbStatement::ReadIntoObject(UObject* ObjectToFill)
 				}
 			}
 		}
+	} else 
+	{
+		rc = false;
 	}
 
 	/* Reset the statement when we are done with it. */
 	PreparedStatement->Reset();
+	return rc;
 }
 
 void UDbStatement::WriteFromObject(UObject* ObjectToSave)

--- a/Plugins/SqliteGameDB/Source/SqliteGameDB/Public/DbStatement.h
+++ b/Plugins/SqliteGameDB/Source/SqliteGameDB/Public/DbStatement.h
@@ -119,7 +119,8 @@ public:
 	T* CreateObjectFromData()
 	{
 		T* ResultObject = NewObject<T>();
-		ReadIntoObject(ResultObject);
+		if (!ReadIntoObject(ResultObject))
+			return nullptr;
 		return ResultObject;
 	}
 
@@ -179,8 +180,11 @@ private:
 	static TArray<FProperty*> FindSaveProperties(UStruct* ThisClass);
 
 	/* Executes the prepared statement and tries to fill the provided object
-	 * with the returned data. */
-	void ReadIntoObject(UObject* ObjectToFill);
+	 * with the returned data.
+	 *
+  	 * Returns `true` if data was returned from the database, else `false`.
+	 */
+	bool ReadIntoObject(UObject* ObjectToFill);
 
 	/*void ReadIntoStruct(UScriptStruct* StructType, void* Thing);*/
 


### PR DESCRIPTION
Previously, this routine would always return a valid object, so the caller would get inconsistent results when no data was actually returned from the database.