### PR TITLE
Unreal Engine 5.4 Build Error Fix

### DIFF
--- a/Plugins/SqliteGameDB/Source/SqliteGameDB/Private/DbBase.cpp
+++ b/Plugins/SqliteGameDB/Source/SqliteGameDB/Private/DbBase.cpp
@@ -33,9 +33,9 @@ void UDbBase::Initialize(FString DatabaseFilePath, FGameDbConfig Config)
 	// All the basic checks return OK, time to try to connect to the Db...
 	SqliteDb = new FSQLiteDatabase();
 
-	verifyf(SqliteDb->Open(*DbFilePath, ESQLiteDatabaseOpenMode::ReadWrite), TEXT(
-		        "Attempt to open DB connection failed, reason: %s \n"
-		        "Unreal requires an exclusive lock to the DB file."));
+	verifyf(SqliteDb->Open(*DbFilePath, ESQLiteDatabaseOpenMode::ReadWrite),
+		TEXT("Attempt to open DB connection failed, reason: %s \n"),
+		TEXT("Unreal requires an exclusive lock to the DB file."));
 
 	UE_LOG(LogSqliteGameDB, Log, TEXT("Connection to DB opened successfully. %s"), *DbFilePath);
 


### PR DESCRIPTION
Fixed an issue where it won't be able to build on Unreal Engine Version 5.4.1 because of a missing argument in verifyf.
See the changes below...