### PR TITLE
Bugfix in PreparedStatementGroup.h

### DIFF
--- a/Plugins/SqliteGameDB/Source/SqliteGameDB/Public/PreparedStatementGroup.h
+++ b/Plugins/SqliteGameDB/Source/SqliteGameDB/Public/PreparedStatementGroup.h
@@ -61,7 +61,7 @@ private:
 
 	GENERATED_BODY()
 
-	const FString Q_HasQueries = TEXT("select count(*) as HasQueries from sqlite_master where name like 'Queries'");
+	const FString Q_HasQueries = TEXT("select count(*) as HasQueries from sqlite_master where name = 'Queries'");
 	const FString Q_ListQueries = TEXT("select * from queries {0} order by Key");
-	const FString Q_FilterQueries = TEXT(" where SchemaName = '{0}';");
+	const FString Q_FilterQueries = TEXT(" where SchemaName = '{0}'");
 };


### PR DESCRIPTION
Hey Ysgrathe! Nice project! I found some minor issues while using it, so I published a CR to address them. Thank you!

1. A `LIKE xxx` statement without '%' is equivalent to using '=' directly, but '=' has better performance than using LIKE.
2. The ';' is redundant.